### PR TITLE
=previous code changes for HBASE and new changes for HIVE 3.1

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.hive.ExploreUtils;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
-import org.apache.hadoop.hive.thrift.DelegationTokenIdentifier;
+import org.apache.hadoop.hive.metastore.security.DelegationTokenIdentifier;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -106,7 +106,9 @@ public final class HiveTokenUtils {
         String user = UserGroupInformation.getCurrentUser().getShortUserName();
         String tokenStr = (String) getDelegationTokenMethod.invoke(hiveConnection, user, user);
         Token<DelegationTokenIdentifier> delegationToken = new Token<>();
-        delegationToken.decodeFromUrlString(tokenStr);
+        Token delegationTokenA = new Token();
+
+        delegationTokenA.decodeFromUrlString(tokenStr);
         LOG.debug("Adding delegation token {} from HiveServer2 for service {} for user {}",
                   delegationToken, delegationToken.getService(), user);
         credentials.addToken(delegationToken.getService(), delegationToken);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
@@ -106,9 +106,9 @@ public final class HiveTokenUtils {
         String user = UserGroupInformation.getCurrentUser().getShortUserName();
         String tokenStr = (String) getDelegationTokenMethod.invoke(hiveConnection, user, user);
         Token<DelegationTokenIdentifier> delegationToken = new Token<>();
-        Token delegationTokenA = new Token();
+//        Token delegationTokenA = new Token();
 
-        delegationTokenA.decodeFromUrlString(tokenStr);
+        delegationToken.decodeFromUrlString(tokenStr);
         LOG.debug("Adding delegation token {} from HiveServer2 for service {} for user {}",
                   delegationToken, delegationToken.getService(), user);
         credentials.addToken(delegationToken.getService(), delegationToken);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/DelegatingHBaseTableUtil.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/DelegatingHBaseTableUtil.java
@@ -26,8 +26,10 @@ import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Table;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,7 +45,7 @@ class DelegatingHBaseTableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
+  public Table createHTable(Configuration conf, TableId tableId) throws IOException {
     return delegate.createHTable(conf, tableId);
   }
 
@@ -63,17 +65,17 @@ class DelegatingHBaseTableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
+  public HTableDescriptor getHTableDescriptor(Admin admin, TableId tableId) throws IOException {
     return delegate.getHTableDescriptor(admin, tableId);
   }
 
   @Override
-  public boolean hasNamespace(HBaseAdmin admin, String namespace) throws IOException {
+  public boolean hasNamespace(Admin admin, String namespace) throws IOException {
     return delegate.hasNamespace(admin, namespace);
   }
 
   @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
+  public boolean tableExists(Admin admin, TableId tableId) throws IOException {
     return delegate.tableExists(admin, tableId);
   }
 
@@ -88,17 +90,17 @@ class DelegatingHBaseTableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
+  public List<HRegionInfo> getTableRegions(Admin admin, TableId tableId) throws IOException {
     return delegate.getTableRegions(admin, tableId);
   }
 
   @Override
-  public List<TableId> listTablesInNamespace(HBaseAdmin admin, String namespaceId) throws IOException {
+  public List<TableId> listTablesInNamespace(Admin admin, String namespaceId) throws IOException {
     return delegate.listTablesInNamespace(admin, namespaceId);
   }
 
   @Override
-  public List<TableId> listTables(HBaseAdmin admin) throws IOException {
+  public List<TableId> listTables(Admin admin) throws IOException {
     return delegate.listTables(admin);
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/HiveUtilities.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/HiveUtilities.java
@@ -19,8 +19,10 @@ package co.cask.cdap.explore;
 import co.cask.cdap.explore.service.ExploreException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
-import org.apache.hive.service.cli.thrift.TColumnValue;
+//import org.apache.hive.service.cli.thrift.TColumnValue;
+import org.apache.hive.service.rpc.thrift.TColumnValue;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -51,7 +53,8 @@ public class HiveUtilities {
     } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
       try {
         // Else try Utilities.deserializeExpression(String)
-        expr = Utilities.deserializeExpression(serializedExpr);
+        expr = SerializationUtilities.deserializeExpression(serializedExpr);
+//        expr = Utilities.deserializeExpression(serializedExpr);
       } catch (NoSuchMethodError e2) {
         try {
           // Else try SerializationUtilities.deserializeExpression(serializedExpr)

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -91,6 +91,7 @@ import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.SessionHandle;
 import org.apache.hive.service.cli.TableSchema;
+import org.apache.hive.service.server.HiveServer2;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionSystemClient;

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
@@ -41,9 +41,9 @@ import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.OperationStatus;
 import org.apache.hive.service.cli.SessionHandle;
-import org.apache.hive.service.cli.thrift.TColumnValue;
-import org.apache.hive.service.cli.thrift.TRow;
-import org.apache.hive.service.cli.thrift.TRowSet;
+import org.apache.hive.service.rpc.thrift.TColumnValue;
+import org.apache.hive.service.rpc.thrift.TRow;
+import org.apache.hive.service.rpc.thrift.TRowSet;
 import org.apache.tephra.TransactionSystemClient;
 
 import java.io.File;
@@ -108,7 +108,9 @@ public class Hive12CDH5ExploreService extends BaseHiveExploreService {
   @Override
   protected QueryStatus doFetchStatus(OperationHandle handle)
     throws HiveSQLException, ExploreException, HandleNotFoundException {
-    OperationStatus operationStatus = getCliService().getOperationStatus(handle);
+    // TODO Setting getProgressUpdate as true for now
+    Boolean getProgressUpdate = true;
+    OperationStatus operationStatus = getCliService().getOperationStatus(handle, getProgressUpdate);
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     HiveSQLException hiveExn = operationStatus.getOperationException();
     if (hiveExn != null) {

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
@@ -42,9 +42,12 @@ import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.OperationState;
 import org.apache.hive.service.cli.SessionHandle;
-import org.apache.hive.service.cli.thrift.TColumnValue;
-import org.apache.hive.service.cli.thrift.TRow;
-import org.apache.hive.service.cli.thrift.TRowSet;
+//import org.apache.hive.service.cli.thrift.TColumnValue;
+//import org.apache.hive.service.cli.thrift.TRow;
+//import org.apache.hive.service.cli.thrift.TRowSet;
+import org.apache.hive.service.rpc.thrift.TRowSet;
+import org.apache.hive.service.rpc.thrift.TRow;
+import org.apache.hive.service.rpc.thrift.TColumnValue;
 import org.apache.tephra.TransactionSystemClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,8 +105,12 @@ public class Hive12ExploreService extends BaseHiveExploreService {
     Object rowSet = fetchResultsMethod.invoke(getCliService(), handle, fetchOrientation, size);
 
     ImmutableList.Builder<QueryResult> rowsBuilder = ImmutableList.builder();
-    Class rowSetClass = Class.forName("org.apache.hive.service.cli.RowSet");
-    Method toTRowSetMethod = rowSetClass.getMethod("toTRowSet");
+    //Class rowSetClass = Class.forName("org.apache.hive.service.cli.RowSet");
+
+    Class rowSetClass = Class.forName("org.apache.hive.service.cli.RowBasedSet");
+//    Method toTRowSetA =rowSetClass.getMethod("toTRowSet");
+//    toTRowSetA.invoke(rowSet);
+    Method toTRowSetMethod = rowSetClass.getMethod("RowBasedSet");
     TRowSet tRowSet = (TRowSet) toTRowSetMethod.invoke(rowSet);
     for (TRow tRow : tRowSet.getRows()) {
       List<Object> cols = Lists.newArrayList();

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -42,6 +42,7 @@ import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.OperationStatus;
 import org.apache.hive.service.cli.RowSet;
 import org.apache.hive.service.cli.SessionHandle;
+import org.apache.hive.service.server.HiveServer2;
 import org.apache.tephra.TransactionSystemClient;
 
 import java.io.File;
@@ -73,6 +74,8 @@ public class Hive13ExploreService extends BaseHiveExploreService {
   @Override
   protected CLIService createCLIService() {
     try {
+//      HiveServer2 hiveServer2 = new HiveServer2();
+//      CLIService.class.getConstructor(hiveServer2).newInstance();
       return CLIService.class.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException("Failed to instantiate CLIService", e);
@@ -99,7 +102,7 @@ public class Hive13ExploreService extends BaseHiveExploreService {
   @Override
   protected QueryStatus doFetchStatus(OperationHandle operationHandle)
     throws HiveSQLException, ExploreException, HandleNotFoundException {
-    OperationStatus operationStatus = getCliService().getOperationStatus(operationHandle);
+    OperationStatus operationStatus = getCliService().getOperationStatus(operationHandle, true);
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     HiveSQLException hiveExn = operationStatus.getOperationException();
     if (hiveExn != null) {

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
@@ -35,7 +35,8 @@ import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
+//import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;   // used Abstract class SerDe instead of SerDe interface
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -55,7 +56,7 @@ import java.util.Properties;
  * SerDe to serialize Dataset Objects. It MUST implement the deprecated SerDe interface instead of extending the
  * abstract SerDe class, otherwise we get ClassNotFound exceptions on cdh4.x.
  */
-public class DatasetSerDe implements SerDe {
+public class DatasetSerDe extends AbstractSerDe {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetSerDe.class);
   private static final SchemaGenerator schemaGenerator = new ReflectionSchemaGenerator();
 

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetStorageHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetStorageHandler.java
@@ -23,7 +23,8 @@ import co.cask.cdap.hive.context.CConfCodec;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+//import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapred.SequenceFileOutputFormat;
@@ -61,7 +62,7 @@ public class DatasetStorageHandler extends DefaultStorageHandler {
   }
 
   @Override
-  public Class<? extends SerDe> getSerDeClass() {
+  public Class<? extends AbstractSerDe> getSerDeClass() {
     return DatasetSerDe.class;
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamSerDe.java
@@ -32,7 +32,8 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
+//import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -51,7 +52,7 @@ import java.util.Properties;
  * abstract SerDe class, otherwise we get ClassNotFound exceptions on cdh4.x.
  */
 @SuppressWarnings("deprecation")
-public class StreamSerDe implements SerDe {
+public class StreamSerDe extends AbstractSerDe {
   private static final Logger LOG = LoggerFactory.getLogger(StreamSerDe.class);
   // timestamp and headers are guaranteed to be the first columns in a stream table.
   // the rest of the columns are for the stream body.

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamStorageHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamStorageHandler.java
@@ -20,7 +20,8 @@ import co.cask.cdap.common.conf.Constants;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+//import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.mapred.InputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +45,7 @@ public class StreamStorageHandler extends DefaultStorageHandler {
   }
 
   @Override
-  public Class<? extends SerDe> getSerDeClass() {
+  public Class<? extends AbstractSerDe> getSerDeClass() {
     return StreamSerDe.class;
   }
 

--- a/cdap-hbase-compat-2.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase20/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-2.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase20/MessageTableRegionObserver.java
@@ -123,6 +123,7 @@ public class MessageTableRegionObserver implements RegionCoprocessor,RegionObser
     if(!(store instanceof HStore)){
     	throw new RuntimeException("store is not an instance of HStore");
     }
+    LOG.info("preFlushScanerOpen has been accessed");
 //    return new LoggingInternalScanner("MessageDataFilter", "preFlush",
 //                                      new StoreScanner((HStore) store, ((HStore)store).getScanInfo(),
 //                                                       Collections.singletonList(memstoreScanner),
@@ -166,6 +167,7 @@ public class MessageTableRegionObserver implements RegionCoprocessor,RegionObser
     if(!(store instanceof HStore)){
     	throw new RuntimeException("store is not an instance of HStore");
     }
+    LOG.info("preCompactScanerOpen has been accessed");
 //    return new LoggingInternalScanner("MessageDataFilter", "preCompact",
 //                                      new StoreScanner((HStore)store, ((HStore)store).getScanInfo(), scanners, scanType,
 //                                                       store.getSmallestReadPoint(), earliestPutTs), txVisibilityState);

--- a/cdap-hbase-compat-2.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase20/PayloadTableRegionObserver.java
+++ b/cdap-hbase-compat-2.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase20/PayloadTableRegionObserver.java
@@ -92,7 +92,7 @@ public class PayloadTableRegionObserver implements RegionCoprocessor, RegionObse
     Scan scan = new Scan();
     scan.setFilter(new PayloadDataFilter(c.getEnvironment(), System.currentTimeMillis(), prefixLength,
             topicMetadataCache));
-
+    LOG.info("preFlushScannerOpen is being accessed");
 //    if (!(store instanceof HStore)) {
 //      throw new RuntimeException("store is not an instance of HStore");
 //    }
@@ -108,7 +108,7 @@ public class PayloadTableRegionObserver implements RegionCoprocessor, RegionObse
     Scan scan = new Scan();
     scan.setFilter(new PayloadDataFilter(c.getEnvironment(), System.currentTimeMillis(), prefixLength,
                                          topicMetadataCache));
-    
+    LOG.info("preCompactScannerOpen is being accessed");
 //    if(!(store instanceof HStore)){
 //    	throw new RuntimeException("store is not an instance of HStore");
 //    }

--- a/cdap-hbase-compat-2.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase20TableUtil.java
+++ b/cdap-hbase-compat-2.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase20TableUtil.java
@@ -124,7 +124,7 @@ public class HBase20TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
+  public List<HRegionInfo> getTableRegions(Admin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
     return admin.getTableRegions(HTableNameConverter.toTableName(tablePrefix, tableId));
@@ -144,7 +144,7 @@ public class HBase20TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public List<TableId> listTables(HBaseAdmin admin) throws IOException {
+  public List<TableId> listTables(Admin admin) throws IOException {
     List<TableId> tableIds = Lists.newArrayList();
     HTableDescriptor[] hTableDescriptors = admin.listTables();
     for (HTableDescriptor hTableDescriptor : hTableDescriptors) {

--- a/cdap-hbase-compat-2.0/src/test/java/co/cask/cdap/data2/increment/hbase20/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-2.0/src/test/java/co/cask/cdap/data2/increment/hbase20/IncrementSummingScannerTest.java
@@ -31,23 +31,9 @@ import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.CellUtil;
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HRegionInfo;
-import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.MockRegionServerServices;
-import org.apache.hadoop.hbase.ServerName;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.regionserver.HRegion;
-import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
-import org.apache.hadoop.hbase.regionserver.RegionScanner;
-import org.apache.hadoop.hbase.regionserver.ScanType;
-import org.apache.hadoop.hbase.regionserver.ScannerContext;
+import org.apache.hadoop.hbase.*;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WALFactory;
@@ -92,7 +78,7 @@ public class IncrementSummingScannerTest {
 
       // test handling of a single increment value alone
       Put p = new Put(Bytes.toBytes("r1"));
-      p.add(familyBytes, columnBytes, Bytes.toBytes(3L));
+      p.addColumn(familyBytes, columnBytes, Bytes.toBytes(3L));
       p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
       region.put(p);
 
@@ -104,11 +90,11 @@ public class IncrementSummingScannerTest {
       assertEquals(1, results.size());
       Cell cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(3L, Bytes.toLong(cell.getValue()));
+      assertEquals(3L, Bytes.toLong(CellUtil.cloneValue(cell)));
 
       // test handling of a single total sum
       p = new Put(Bytes.toBytes("r2"));
-      p.add(familyBytes, columnBytes, Bytes.toBytes(5L));
+      p.addColumn(familyBytes, columnBytes, Bytes.toBytes(5L));
       region.put(p);
 
       scan = new Scan(Bytes.toBytes("r2"));
@@ -120,13 +106,13 @@ public class IncrementSummingScannerTest {
       assertEquals(1, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(5L, Bytes.toLong(cell.getValue()));
+      assertEquals(5L, Bytes.toLong(CellUtil.cloneValue(cell)));
 
       // test handling of multiple increment values
       long now = System.currentTimeMillis();
       p = new Put(Bytes.toBytes("r3"));
       for (int i = 0; i < 5; i++) {
-        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes((long) (i + 1)));
+        p.addColumn(familyBytes, columnBytes, now - i, Bytes.toBytes((long) (i + 1)));
       }
       p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
       region.put(p);
@@ -140,20 +126,20 @@ public class IncrementSummingScannerTest {
       assertEquals(1, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(15L, Bytes.toLong(cell.getValue()));
+      assertEquals(15L, Bytes.toLong(CellUtil.cloneValue(cell)));
 
       // test handling of multiple increment values followed by a total sum, then other increments
       now = System.currentTimeMillis();
       p = new Put(Bytes.toBytes("r4"));
       for (int i = 0; i < 3; i++) {
-        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
       }
       p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
       region.put(p);
 
       // this put will appear as a "total" sum prior to all the delta puts
       p = new Put(Bytes.toBytes("r4"));
-      p.add(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
+      p.addColumn(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
       region.put(p);
 
       scan = new Scan(Bytes.toBytes("r4"));
@@ -165,11 +151,11 @@ public class IncrementSummingScannerTest {
       assertEquals(1, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(8L, Bytes.toLong(cell.getValue()));
+      assertEquals(8L, Bytes.toLong(CellUtil.cloneValue(cell)));
 
       // test handling of an increment column followed by a non-increment column
       p = new Put(Bytes.toBytes("r4"));
-      p.add(familyBytes, Bytes.toBytes("c2"), Bytes.toBytes("value"));
+      p.addColumn(familyBytes, Bytes.toBytes("c2"), Bytes.toBytes("value"));
       region.put(p);
 
       scan = new Scan(Bytes.toBytes("r4"));
@@ -181,21 +167,21 @@ public class IncrementSummingScannerTest {
       assertEquals(2, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(8L, Bytes.toLong(cell.getValue()));
+      assertEquals(8L, Bytes.toLong(CellUtil.cloneValue(cell)));
 
       cell = results.get(1);
       assertNotNull(cell);
-      assertEquals("value", Bytes.toString(cell.getValue()));
+      assertEquals("value", Bytes.toString(CellUtil.cloneValue(cell)));
 
       // test handling of an increment column followed by a delete
       now = System.currentTimeMillis();
       Delete d = new Delete(Bytes.toBytes("r5"));
-      d.deleteColumn(familyBytes, columnBytes, now - 3);
+      d.addColumn(familyBytes, columnBytes, now - 3);
       region.delete(d);
 
       p = new Put(Bytes.toBytes("r5"));
       for (int i = 2; i >= 0; i--) {
-        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
       }
       p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
       region.put(p);
@@ -211,7 +197,7 @@ public class IncrementSummingScannerTest {
       assertEquals(2, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
+      assertEquals(3L, Bytes.toLong(CellUtil.cloneValue(cell), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
       // next cell should be the delete
       cell = results.get(1);
       assertTrue(CellUtil.isDelete(cell));
@@ -235,7 +221,7 @@ public class IncrementSummingScannerTest {
       byte[] row1 = Bytes.toBytes("row1");
       for (int i = 0; i < 50; i++) {
         Put p = new Put(row1);
-        p.add(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
         p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
         ts++;
         region.put(p);
@@ -245,17 +231,17 @@ public class IncrementSummingScannerTest {
       ts = System.currentTimeMillis();
       // start with a full put
       Put row2P = new Put(row2);
-      row2P.add(familyBytes, columnBytes, ts++, Bytes.toBytes(10L));
+      row2P.addColumn(familyBytes, columnBytes, ts++, Bytes.toBytes(10L));
       region.put(row2P);
       for (int i = 0; i < 10; i++) {
         Put p = new Put(row2);
-        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
         p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
         region.put(p);
       }
 
       // force a region flush
-      region.flushcache(true, false);
+      region.flushcache(true, false, FlushLifeCycleTracker.DUMMY);
       region.waitForFlushesAndCompactions();
 
       Result r1 = region.get(new Get(row1));
@@ -264,7 +250,7 @@ public class IncrementSummingScannerTest {
       // row1 should have a full put aggregating all 50 incrments
       Cell r1Cell = r1.getColumnLatestCell(familyBytes, columnBytes);
       assertNotNull(r1Cell);
-      assertEquals(50L, Bytes.toLong(r1Cell.getValue()));
+      assertEquals(50L, Bytes.toLong(CellUtil.cloneValue(r1Cell)));
 
       Result r2 = region.get(new Get(row2));
       assertNotNull(r2);
@@ -272,12 +258,12 @@ public class IncrementSummingScannerTest {
       // row2 should have a full put aggregating prior put + 10 increments
       Cell r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
       assertNotNull(r2Cell);
-      assertEquals(20L, Bytes.toLong(r2Cell.getValue()));
+      assertEquals(20L, Bytes.toLong(CellUtil.cloneValue(r2Cell)));
 
       // add 30 more increments to row2
       for (int i = 0; i < 30; i++) {
         Put p = new Put(row2);
-        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
         p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
         region.put(p);
       }
@@ -288,16 +274,16 @@ public class IncrementSummingScannerTest {
       assertFalse(r2.isEmpty());
       r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
       assertNotNull(r2Cell);
-      assertEquals(50L, Bytes.toLong(r2Cell.getValue()));
+      assertEquals(50L, Bytes.toLong(CellUtil.cloneValue(r2Cell)));
 
       // force another region flush
-      region.flushcache(true, false);
+      region.flushcache(true, false, FlushLifeCycleTracker.DUMMY);
       region.waitForFlushesAndCompactions();
 
       // add 100 more increments to row2
       for (int i = 0; i < 100; i++) {
         Put p = new Put(row2);
-        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
         p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
         region.put(p);
       }
@@ -308,7 +294,7 @@ public class IncrementSummingScannerTest {
       assertFalse(r2.isEmpty());
       r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
       assertNotNull(r2Cell);
-      assertEquals(150L, Bytes.toLong(r2Cell.getValue()));
+      assertEquals(150L, Bytes.toLong(CellUtil.cloneValue(r2Cell)));
     } finally {
       region.close();
     }
@@ -326,33 +312,33 @@ public class IncrementSummingScannerTest {
       long now = System.currentTimeMillis();
       // put a non increment columns
       Put p = new Put(Bytes.toBytes("r4"));
-      p.add(familyBytes, Bytes.toBytes("c1"), Bytes.toBytes("value1"));
+      p.addColumn(familyBytes, Bytes.toBytes("c1"), Bytes.toBytes("value1"));
       region.put(p);
 
       // now put some increment deltas in a column
       p = new Put(Bytes.toBytes("r4"));
       for (int i = 0; i < 3; i++) {
-        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
       }
       p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
       region.put(p);
 
       // put some non - increment columns
       p = new Put(Bytes.toBytes("r4"));
-      p.add(familyBytes, Bytes.toBytes("c3"), Bytes.toBytes("value3"));
+      p.addColumn(familyBytes, Bytes.toBytes("c3"), Bytes.toBytes("value3"));
       region.put(p);
 
       p = new Put(Bytes.toBytes("r4"));
-      p.add(familyBytes, Bytes.toBytes("c4"), Bytes.toBytes("value4"));
+      p.addColumn(familyBytes, Bytes.toBytes("c4"), Bytes.toBytes("value4"));
       region.put(p);
 
       p = new Put(Bytes.toBytes("r4"));
-      p.add(familyBytes, Bytes.toBytes("c5"), Bytes.toBytes("value5"));
+      p.addColumn(familyBytes, Bytes.toBytes("c5"), Bytes.toBytes("value5"));
       region.put(p);
 
       // this put will appear as a "total" sum prior to all the delta puts
       p = new Put(Bytes.toBytes("r4"));
-      p.add(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
+      p.addColumn(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
       region.put(p);
 
       Scan scan = new Scan(Bytes.toBytes("r4"));
@@ -364,13 +350,13 @@ public class IncrementSummingScannerTest {
       assertEquals(3, results.size());
       Cell cell = results.get(0);
       assertNotNull(cell);
-      assertEquals("value1", Bytes.toString(cell.getValue()));
+      assertEquals("value1", Bytes.toString(CellUtil.cloneValue(cell)));
       cell = results.get(1);
       assertNotNull(cell);
-      assertEquals(8L, Bytes.toLong(cell.getValue()));
+      assertEquals(8L, Bytes.toLong(CellUtil.cloneValue(cell)));
       cell = results.get(2);
       assertNotNull(cell);
-      assertEquals("value3", Bytes.toString(cell.getValue()));
+      assertEquals("value3", Bytes.toString(CellUtil.cloneValue(cell)));
     } finally {
       region.close();
     }
@@ -392,12 +378,12 @@ public class IncrementSummingScannerTest {
 
       // Initial put to row1,c2
       Put row1P = new Put(row1);
-      row1P.add(familyBytes, columnBytes2, now - 1, Bytes.toBytes(5L));
+      row1P.addColumn(familyBytes, columnBytes2, now - 1, Bytes.toBytes(5L));
       region.put(row1P);
 
       // Initial put to row2,c
       Put row2P = new Put(row2);
-      row2P.add(familyBytes, columnBytes, now - 1, Bytes.toBytes(10L));
+      row2P.addColumn(familyBytes, columnBytes, now - 1, Bytes.toBytes(10L));
       region.put(row2P);
 
       // Generate some increments
@@ -421,23 +407,23 @@ public class IncrementSummingScannerTest {
       assertEquals(2, results.size());
       Cell cell = results.get(0);
       assertNotNull(cell);
-      assertEquals("row1", Bytes.toString(cell.getRow()));
-      assertEquals("c", Bytes.toString(cell.getQualifier()));
-      assertEquals(50, Bytes.toLong(cell.getValue()));
+      assertEquals("row1", Bytes.toString(cell.getRowArray()));
+      assertEquals("c", Bytes.toString(CellUtil.cloneQualifier(cell)));
+      assertEquals(50, Bytes.toLong(CellUtil.cloneValue(cell)));
 
       cell = results.get(1);
       assertNotNull(cell);
-      assertEquals("row1", Bytes.toString(cell.getRow()));
-      assertEquals("c2", Bytes.toString(cell.getQualifier()));
-      assertEquals(55, Bytes.toLong(cell.getValue()));
+      assertEquals("row1", Bytes.toString(cell.getRowArray()));
+      assertEquals("c2", Bytes.toString(CellUtil.cloneQualifier(cell)));
+      assertEquals(55, Bytes.toLong(CellUtil.cloneValue(cell)));
 
       results.clear();
       assertFalse(scanner.next(results, ScannerContext.newBuilder().setBatchLimit(10).build()));
       assertEquals(1, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals("row2", Bytes.toString(cell.getRow()));
-      assertEquals(60, Bytes.toLong(cell.getValue()));
+      assertEquals("row2", Bytes.toString(cell.getRowArray()));
+      assertEquals(60, Bytes.toLong(CellUtil.cloneValue(cell)));
     } finally {
       region.close();
     }
@@ -460,7 +446,7 @@ public class IncrementSummingScannerTest {
       // adding 5 delta increments
       for (int i = 0; i < 5; i++) {
         Put p = new Put(Bytes.toBytes("r1"), now++);
-        p.add(familyBytes, columnBytes, Bytes.toBytes(1L));
+        p.addColumn(familyBytes, columnBytes, Bytes.toBytes(1L));
         p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
         region.put(p);
         counter1++;
@@ -493,7 +479,7 @@ public class IncrementSummingScannerTest {
       int counter2 = 0;
       for (int i = 0; i < 5; i++) {
         Put p = new Put(Bytes.toBytes("r2"), now + i);
-        p.add(familyBytes, columnBytes, Bytes.toBytes(2L));
+        p.addColumn(familyBytes, columnBytes, Bytes.toBytes(2L));
         p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
         region.put(p);
         counter2 += 2;
@@ -516,7 +502,7 @@ public class IncrementSummingScannerTest {
 
   private Put generateIncrementPut(byte[] familyBytes, byte[] columnBytes, byte [] row, long ts) {
     Put p = new Put(row);
-    p.add(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
+    p.addColumn(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
     p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
     return p;
   }
@@ -535,7 +521,7 @@ public class IncrementSummingScannerTest {
       assertEquals(1, results.size());
       Cell cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(count, Bytes.toLong(cell.getValue()));
+      assertEquals(count, Bytes.toLong(CellUtil.cloneValue(cell)));
     }
     assertFalse(hasMore);
   }
@@ -560,7 +546,7 @@ public class IncrementSummingScannerTest {
       assertEquals(1, results.size());
       Cell cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(count, Bytes.toLong(cell.getValue()));
+      assertEquals(count, Bytes.toLong(CellUtil.cloneValue(cell)));
     }
     assertFalse(hasMore);
   }
@@ -574,7 +560,7 @@ public class IncrementSummingScannerTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
-    cfd.setKeepDeletedCells(true);
+    cfd.setKeepDeletedCells(KeepDeletedCells.TRUE);
     htd.addFamily(cfd);
     htd.addCoprocessor(IncrementHandler.class.getName());
 
@@ -584,9 +570,9 @@ public class IncrementSummingScannerTest {
     Path hlogPath = new Path("/tmp/hlog-" + tableName);
     FileSystem fs = FileSystem.get(hConf);
     assertTrue(fs.mkdirs(tablePath));
-    WALFactory walFactory = new WALFactory(hConf, null, hlogPath.toString());
-    WAL hLog = walFactory.getWAL(new byte[]{1});
+    WALFactory walFactory = new WALFactory(hConf, hlogPath.toString());
     HRegionInfo regionInfo = new HRegionInfo(desc.getTableName());
+    WAL hLog = walFactory.getWAL(regionInfo);
     HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
     return new HRegion(regionFS, hLog, hConf, desc,
                        new LocalRegionServerServices(hConf, ServerName.valueOf(

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -435,7 +435,7 @@ public abstract class HBaseTableUtil {
    * @return a list of {@link HRegionInfo} for the specified {@link TableId}
    * @throws IOException
    */
-  public abstract List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException;
+  public abstract List<HRegionInfo> getTableRegions(Admin admin, TableId tableId) throws IOException;
 
   /**
    * Deletes all tables in the specified namespace that satisfy the given {@link Predicate}.
@@ -483,7 +483,7 @@ public abstract class HBaseTableUtil {
    * Lists all tables
    * @param admin the {@link HBaseAdmin} to use to communicate with HBase
    */
-  public abstract List<TableId> listTables(HBaseAdmin admin) throws IOException;
+  public abstract List<TableId> listTables(Admin admin) throws IOException;
 
   /**
    * Disables and deletes a table.

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
@@ -46,6 +46,7 @@ import com.google.common.collect.Maps;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionManager;
@@ -98,7 +99,7 @@ public class HBaseTableCoprocessorTestRun extends DataCleanupTest {
   private static InvalidTxList invalidList = new InvalidTxList();
 
   private static Configuration hConf;
-  private static HBaseAdmin hBaseAdmin;
+  private static Admin hBaseAdmin;
   private static HBaseTableUtil tableUtil;
   private static TableFactory tableFactory;
   private static HBaseDDLExecutor ddlExecutor;
@@ -216,7 +217,7 @@ public class HBaseTableCoprocessorTestRun extends DataCleanupTest {
       tableId = tableUtil.createHTableId(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME));
     }
 
-    byte[] tableName = tableUtil.getHTableDescriptor(hBaseAdmin, tableId).getName();
+    byte[] tableName = tableUtil.getHTableDescriptor(hBaseAdmin, tableId).getTableName().getName();
     HBASE_TEST_BASE.forceRegionFlush(tableName);
     HBASE_TEST_BASE.forceRegionCompact(tableName, true);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <hbase96.version>0.96.2-hadoop2</hbase96.version>
     <hbase98.version>0.98.6.1-hadoop2</hbase98.version>-->
 	<hbase20.version>2.0.2</hbase20.version>
-    <hive.version>1.2.1</hive.version>
+    <hive.version>3.1.0</hive.version>
     <hsql.version>2.2.4</hsql.version>
     <http.component.version>4.3.2</http.component.version>
     <javamail.version>1.4.1</javamail.version>


### PR DESCRIPTION
Hive 3.1 changes in cdap-explore. 

cdap-explore/src/main/java/co/cask/cdap/explore/HiveUtilities.java                                                               |   7 ++-
 cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java                                         |   1 +
 cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java                                       |  10 ++--
 cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java                                           |  17 +++++--
 cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java                                           |   5 +-
 cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java                                                          |   5 +-
 cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetStorageHandler.java                                                 |   5 +-
 cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamSerDe.java                                                             |   5 +-
 cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamStorageHandler.java  