### PR TITLE
#[RAFD-991]:removed timeout for  popover form  nodes

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -216,11 +216,12 @@ angular.module(PKG.name + '.commons')
 
             // Needs a timeout here to avoid showing popups instantly when just moving
             // cursor across a node
-            metricsPopoverTimeout = $timeout(function () {
+            // workarround for fix of https://guavus-jira.atlassian.net/browse/RAFD-991 ,remove timeout make popover available instantly
+            // metricsPopoverTimeout = $timeout(function () {
               if (nodeInfo.popover && typeof nodeInfo.popover.show === 'function') {
                 nodeInfo.popover.show();
               }
-            }, 500);
+            // }, 500);
           });
       }
     };


### PR DESCRIPTION
RCA:- As per analysis I can conclude following point related to this issue:—
1. This issue is originated from CDAP-UI not from playbook app.
2. It is because of null pointer exception thrown from angular-strap(3rd party libs) not because of memory leak.
3. It is OPEN bug in CDAP - https://issues.cask.co/browse/CDAP-12840

Possible Workarounds:-
1. Fix in angular-strap(3rd party libs) publish it in guavus-artifcatory and use as dependency in cap-ui,here we need to maintain this lib
2. Add fix in cdap-ui — Make showMetrics value as false for all type of plugin, but it will remove metrics popover functionality disable or provide fix and maintain this functionality as it as.


We choose 2nd approach-- As a fix of this issue removed timeout for  popover form  nodes .