### PR TITLE
AFE will send a event on for open/close of new feature wizard

### DIFF
--- a/cdap-ui/app/cdap/components/FeatureUI/LandingPage/index.js
+++ b/cdap-ui/app/cdap/components/FeatureUI/LandingPage/index.js
@@ -55,7 +55,7 @@ import FEDataServiceApi from '../feDataService';
 import { Theme } from 'services/ThemeHelper';
 import StatusBar from "./StatusBar";
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
-import { SUCCEEDED, DEPLOYED, FAILED, RUNNING, FEATURE_GENERATED, FEATURE_SELECTED } from '../config';
+import { SUCCEEDED, DEPLOYED, FAILED, RUNNING, FEATURE_GENERATED, FEATURE_SELECTED, NEW_FEATURE_EVENT } from '../config';
 
 
 require('./LandingPage.scss');
@@ -112,7 +112,7 @@ class LandingPage extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (this.state.showFeatureWizard !== prevState.showFeatureWizard) {
-      var wizard = new CustomEvent('afe-add-new', {detail: {'isOpen': this.state.showFeatureWizard}});
+      var wizard = new CustomEvent(NEW_FEATURE_EVENT, {detail: {'isOpen': this.state.showFeatureWizard}});
       window.top.dispatchEvent(wizard);
     }
   }

--- a/cdap-ui/app/cdap/components/FeatureUI/LandingPage/index.js
+++ b/cdap-ui/app/cdap/components/FeatureUI/LandingPage/index.js
@@ -110,6 +110,13 @@ class LandingPage extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.showFeatureWizard !== prevState.showFeatureWizard) {
+      var wizard = new CustomEvent('afe-add-new', {detail: {'isOpen': this.state.showFeatureWizard}});
+      window.top.dispatchEvent(wizard);
+    }
+  }
+
 
   fetchWizardData() {
     this.fetchProperties();
@@ -127,6 +134,7 @@ class LandingPage extends React.Component {
     this.setState({
       showFeatureWizard: open
     });
+
   }
 
   toggleDropDown() {

--- a/cdap-ui/app/cdap/components/FeatureUI/config.js
+++ b/cdap-ui/app/cdap/components/FeatureUI/config.js
@@ -83,6 +83,7 @@ export const DELETE = "delete";
 
 export const FEATURE_GENERATED = "Feature Generated";
 export const FEATURE_SELECTED = "Feature Selected";
+export const NEW_FEATURE_EVENT = "afe-add-new";
 export const AFEGridColumns = [
   {
     headerName: "Pipeline",


### PR DESCRIPTION
This is required to fix https://guavus-jira.atlassian.net/browse/RAFD-2249
We also need to merge below PR for above to be fixed
https://github.com/Guavus/raf-interactive-playbook-ui/pull/104
However this merge can be carried out independently without affecting anything