### PR TITLE
Rafd 1962 jio

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreRenewer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreRenewer.java
@@ -125,8 +125,15 @@ public class TokenSecureStoreRenewer extends SecureStoreRenewer {
         JobHistoryServerTokenUtils.obtainToken(yarnConf, refreshedCredentials);
       }*/
       if (User.isSecurityEnabled()) {
-        HiveTokenUtils.obtainTokens(cConf, refreshedCredentials);
-        JobHistoryServerTokenUtils.obtainToken(yarnConf, refreshedCredentials);
+        HiveTokenUtils.obtainTokens(cConf, refreshedCredentials);/**
+         * Removed dependency of getting the token from Job history server on CDAP start as,
+         * In HDP 3.1 Hive do not have ATSHook enabled.
+         * It was required for HDP 2.6 where, 
+         * Hive ATSHook should be disabled, so that CDAP Master does not pass 
+         * the delegation token from the Timeline server to the Explore container.
+         * https://guavus-jira.atlassian.net/browse/RAFD-1962
+         */
+//        JobHistoryServerTokenUtils.obtainToken(yarnConf, refreshedCredentials);	
       } 
 
       if (secureStore instanceof DelegationTokensUpdater) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreRenewer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreRenewer.java
@@ -133,7 +133,7 @@ public class TokenSecureStoreRenewer extends SecureStoreRenewer {
          * the delegation token from the Timeline server to the Explore container.
          * https://guavus-jira.atlassian.net/browse/RAFD-1962
          */
-//        JobHistoryServerTokenUtils.obtainToken(yarnConf, refreshedCredentials);	
+//        JobHistoryServerTokenUtils.obtainToken(yarnConf, refreshedCredentials);
       } 
 
       if (secureStore instanceof DelegationTokensUpdater) {


### PR DESCRIPTION
if (secureExplore) is commeted in HDP 2.3.5 branch, however it is uncommneted in 3.1. Also, User.isSecurityEnabled() is commented in HDP 3.1 branch, however its is uncommented in HDP 2.6.5 branch. Not sure why ?

However, to check the JobHistoryServerTokenUtils.obtainToken, have commented its check.