### PR TITLE
Fix/remove script check request body

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -358,8 +358,11 @@ angular.module(PKG.name + '.commons')
       if (vm.isDisabled) {
         endpointObj.enabled = false;
       }
-      let endpoint = vm.instance.addEndpoint(endpointDOMEl, endpointObj);
-      addListenersForEndpoint(endpoint, endpointDOMEl);
+
+      if(endpointDOMEl!==null && endpointDOMEl!== undefined) {
+        let endpoint = vm.instance.addEndpoint(endpointDOMEl, endpointObj);
+        addListenersForEndpoint(endpoint, endpointDOMEl);
+      }
     }
 
     function addEndpointForConditionNode(endpointDOMId, endpointStyle, overlayLabel) {

--- a/cdap-ui/server/urlValidator.js
+++ b/cdap-ui/server/urlValidator.js
@@ -134,14 +134,15 @@ UrlValidator.prototype.isValidRequest = function (url, req) {
   }
 
   // check request body
-  // if(req !== undefined && req !==  null){
-  //   const dirty = JSON.stringify(req);
-  //   // log.info ('\nRequest Body::  ' +dirty);
-  //   const clean = unescape(DOMPurify.sanitize(dirty, { ALLOWED_TAGS: []}));
-  //   validrequest =  clean === dirty ? true : false;
-  // }
+  if(req !== undefined && req !==  null){
+    const dirty = JSON.stringify(req);
+    const clean = unescape(DOMPurify.sanitize(dirty, { ALLOWED_TAGS: []}));
+    validrequest =  clean === dirty ? true : false;
+  }
 
-  return validUrl && validrequest;
+  // TODO need to work on the parsing part to skip the description content.
+  // return validUrl && validrequest;
+  return validUrl;
 };
 
 

--- a/cdap-ui/server/urlValidator.js
+++ b/cdap-ui/server/urlValidator.js
@@ -134,12 +134,12 @@ UrlValidator.prototype.isValidRequest = function (url, req) {
   }
 
   // check request body
-  if(req !== undefined && req !==  null){
-    const dirty = JSON.stringify(req);
-    // log.info ('\nRequest Body::  ' +dirty);
-    const clean = unescape(DOMPurify.sanitize(dirty, { ALLOWED_TAGS: []}));
-    validrequest =  clean === dirty ? true : false;
-  }
+  // if(req !== undefined && req !==  null){
+  //   const dirty = JSON.stringify(req);
+  //   // log.info ('\nRequest Body::  ' +dirty);
+  //   const clean = unescape(DOMPurify.sanitize(dirty, { ALLOWED_TAGS: []}));
+  //   validrequest =  clean === dirty ? true : false;
+  // }
 
   return validUrl && validrequest;
 };


### PR DESCRIPTION
remove script check from request body because some plugins reference content contains script tag. In this check it won't allow the pipelines to deploy.

added a null check because some plugins are unable to connect each other.