### PR TITLE
1.) using '-' instead of ':' in securekey formation     2.) '-' not a…

### DIFF
--- a/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStore.java
+++ b/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStore.java
@@ -59,8 +59,11 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public class KMSSecureStore implements SecureStore, SecureStoreManager, DelegationTokensUpdater {
   private static final Logger LOG = LoggerFactory.getLogger(KMSSecureStore.class);
-  /** Separator between the namespace name and the key name */
-  private static final String NAME_SEPARATOR = ":";
+  /**
+   * Separator between the namespace name and the key name
+   * Changing this to '-' from ':' as kms secure store does not support ':' in key
+   * */
+  private static final String NAME_SEPARATOR = "-";
   /**
    * Hadoop KeyProvider interface. This is used to interact with KMS.
    */

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/SecureKeyId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/SecureKeyId.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  */
 public class SecureKeyId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   // KMS only supports lower case keys.
-  private static final Pattern secureKeyNamePattern = Pattern.compile("[a-z0-9_-]+");
+  private static final Pattern secureKeyNamePattern = Pattern.compile("[a-z0-9_]+");
 
   private final String name;
   private transient Integer hashCode;
@@ -42,7 +42,7 @@ public class SecureKeyId extends NamespacedEntityId implements ParentedId<Namesp
     if (!isValidSecureKey(name)) {
       throw new IllegalArgumentException(String.format("Improperly formatted secure key name '%s'." +
                                                          " The name can contain lower case alphabets," +
-                                                         " numbers, _, and -", name));
+                                                         " numbers, and _", name));
     }
     this.name = name;
   }


### PR DESCRIPTION
…llowed in secure keys