### PR TITLE
RAFD-4052 : data prep css fix (#365)

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrep.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrep.scss
@@ -84,6 +84,16 @@ $toggle-btn-disabled-bg-color: #cccccc;
 
     .dataprep-main {
       height: 100%;
+      display: flex;
+      > .row {
+        margin: 0;
+        height: 100%;
+      }
+    }
+
+    .dataprep-main-content {
+      height: 100%;
+      width: calc(100vw - 540px);
       > .row {
         margin: 0;
         height: 100%;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/DataPrepContentWrapper.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/DataPrepContentWrapper.scss
@@ -20,9 +20,12 @@ $tab_border_bottom_color: #cccccc;
 $tab_font_color: #999999;
 
 .dataprep-content-wrapper {
+  overflow-x: auto;
   height: 100%;
   > .row {
     height: 100%;
+    display: flex;
+    margin: 0;
     [class*="col-"] {
       padding: 0;
       height: 100%;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
@@ -145,7 +145,7 @@ export default class DataPrepContentWrapper extends Component {
   render() {
     const dataPart = (
       <div className="row">
-        <div className="dataprep-main col-xs-9">
+        <div className="dataprep-main-content">
           <DataPrepTable />
           <DataPrepCLI />
         </div>

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DataPrepSidePanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DataPrepSidePanel.scss
@@ -32,6 +32,7 @@ $quality-bar-null-color: #95a5a6;
     border-left: 1px solid $border-color;
     height: 100%;
     padding: 0;
+    min-width: 540px;
 
     .tabs-headers {
       height: $tab-header-height;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
@@ -105,7 +105,7 @@ export default class DataPrepSidePanel extends Component {
 
   render() {
     return (
-      <div className="col-xs-3 dataprep-side-panel">
+      <div className="dataprep-side-panel">
         <div className="tabs">
           <div className="tabs-headers">
             <div

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -77,6 +77,10 @@ $success_alert_bg_color: $brand-success;
         .connection-type {
           font-size: 13px;
           color: $top-panel-connection-color;
+          white-space: nowrap;
+          overflow-y: hidden;
+          overflow-x: hidden;
+          text-overflow: ellipsis;
 
           .connection-name {
             margin-left: 5px;

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -312,7 +312,7 @@ export default class DataPrep extends Component {
         </div>
 
         <div className={`row dataprep-body ${entityClassName}`}>
-          <div className="dataprep-main col-xs-12">
+          <div className="dataprep-main">
             <DataPrepContentWrapper />
           </div>
 


### PR DESCRIPTION
* RAFD-3917: dataprep layout issues

(cherry picked from commit ee488c456f7124d8a36e5581d0cea4c8973aa917)

* RAFD-3917: dataprep refined css layout

(cherry picked from commit e7188ac4546211b4d4870a640fc72192965ade0b)

* RAFD-4052: css fix for data-prep

(cherry picked from commit 4379ac1830861430d07235b479a17e803b219921)

Co-authored-by: niranjan-guavus <niranjan.swain@guavus.com>
(cherry picked from commit c24d98e3a20cbc1eb378eb51f45ebbe38da44fda)