### PR TITLE
RAFD-4212: Sorting icons are not updated on pipeline page

### DIFF
--- a/cdap-ui/app/directives/cask-angular-sortable/sortable.js
+++ b/cdap-ui/app/directives/cask-angular-sortable/sortable.js
@@ -81,11 +81,7 @@ function caskSortableDirective ($log, $stateParams, $state) {
         scope.sortable.predicate = getPredicate(defaultPredicate.addClass('predicate'));
       }
 
-      if (scope.sortable && scope.sortable.reverse) {
-        headers.append('<i class="fa fa-toggle-down"></i>');
-      } else {
-        headers.append('<i class="fa fa-toggle-up"></i>');
-      }
+      headers.append('<i class="fa fa-toggle-down"></i>');
 
       headers.on('click', function() {
         var th = angular.element(this),
@@ -114,7 +110,7 @@ function caskSortableDirective ($log, $stateParams, $state) {
         $state.go($state.$current.name, {
           sortBy:  predicate,
           reverse: scope.sortable.reverse ? 'reverse' : ''
-        });
+        }, {notify: false});
       });
 
     }

--- a/cdap-ui/app/directives/cask-angular-sortable/sortable.js
+++ b/cdap-ui/app/directives/cask-angular-sortable/sortable.js
@@ -81,7 +81,11 @@ function caskSortableDirective ($log, $stateParams, $state) {
         scope.sortable.predicate = getPredicate(defaultPredicate.addClass('predicate'));
       }
 
-      headers.append('<i class="fa fa-toggle-down"></i>');
+      if (scope.sortable && scope.sortable.reverse) {
+        headers.append('<i class="fa fa-toggle-down"></i>');
+      } else {
+        headers.append('<i class="fa fa-toggle-up"></i>');
+      }
 
       headers.on('click', function() {
         var th = angular.element(this),

--- a/cdap-ui/app/hydrator/templates/list.html
+++ b/cdap-ui/app/hydrator/templates/list.html
@@ -120,7 +120,7 @@
             <th data-predicate="name" class="pipeline-name-header">Pipeline name</th>
             <th data-predicate="artifactType">Type</th>
             <th data-predicate="latestRun.status">Status</th>
-            <th skip-sort>Total runs</th>
+            <th skip-sort="true">Total runs</th>
             <th data-predicate="latestRun.starting"
                   data-predicate-default="reverse">Last start time</th>
             <th data-predicate="latestRun.duration">Duration</th>

--- a/cdap-ui/app/hydrator/templates/list.html
+++ b/cdap-ui/app/hydrator/templates/list.html
@@ -120,7 +120,7 @@
             <th data-predicate="name" class="pipeline-name-header">Pipeline name</th>
             <th data-predicate="artifactType">Type</th>
             <th data-predicate="latestRun.status">Status</th>
-            <th data-predicate="numRuns">Total runs</th>
+            <th skip-sort>Total runs</th>
             <th data-predicate="latestRun.starting"
                   data-predicate-default="reverse">Last start time</th>
             <th data-predicate="latestRun.duration">Duration</th>

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -189,7 +189,7 @@ body.theme-cdap {
     td { font-size: 14px; }
 
     &[cask-sortable] {
-      tr.sort-enabled th:hover { background-color: transparent; }
+      tr.sort-enabled th:hover { background-color: #f4f5f7; }
     }
   }
 


### PR DESCRIPTION
added skip sort on total runs (because sorting not working on this column) + corrected sorting icon
(cherry picked from commit 44e81f8b6ad515669d6eb75d0ed53ab8f6f97869)