### PR TITLE
RAFD-1939

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -101,9 +101,6 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
 
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
-    for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
-      sparkConf.set(property.getKey(), property.getValue());
-    }
 
     // spark... makes you set this to at least the number of receivers (streaming sources)
     // because it holds one thread per receiver, or one core in distributed mode.
@@ -157,6 +154,11 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
           String.format("Unable to create checkpoint directory '%s' for the pipeline.", pipelineCheckpointDir));
       }
     }
+    
+    for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
+    	sparkConf.set(property.getKey(), property.getValue());
+    }
+
     WRAPPERLOGGER.info("Pipeline '{}' running", context.getApplicationSpecification().getName());
   }
 


### PR DESCRIPTION
https://guavus-jira.atlassian.net/browse/RAFD-1939
https://issues.cask.co/browse/CDAP-15874

there is some code in that same method that sets anything given in the 'engine config' part of the UI into sparkConf:

```
    for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
      sparkConf.set(property.getKey(), property.getValue());
    }

```

This should happen at the end of the method so that it overrides any defaults set by the app. All of the settings there are meant to be defaults, which advanced users can overwrite.